### PR TITLE
respect ignored fields for mutatable structs

### DIFF
--- a/lain_derive/src/mutations.rs
+++ b/lain_derive/src/mutations.rs
@@ -271,13 +271,16 @@ fn mutatable_enum_visitor(variants: &[Variant], cont_ident: &syn::Ident) -> Vec<
 fn mutatable_struct_visitor(fields: &[Field]) -> Vec<TokenStream> {
     fields
         .iter()
-        .map(|field| {
+        .filter_map(|field| {
+            if field.attrs.ignore() {
+                return None;
+            }
             let (_field_ident, _field_ident_string, initializer) =
                 field_mutator(field, "self.", false);
 
-            quote! {
+            Some(quote! {
                 #initializer
-            }
+            })
         })
         .collect()
 }

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -169,7 +169,7 @@ mod test {
 
     #[test]
     fn test_ignored_fields() {
-        #[derive(NewFuzzed, BinarySerialize, Clone)]
+        #[derive(NewFuzzed, BinarySerialize, Clone, Mutatable)]
         struct IgnoredFieldsStruct {
             #[lain(ignore)]
             ignored: u8,
@@ -177,8 +177,11 @@ mod test {
 
         let mut mutator = get_mutator();
 
-        let initialized_struct = IgnoredFieldsStruct::new_fuzzed(&mut mutator, None);
+        let mut initialized_struct = IgnoredFieldsStruct::new_fuzzed(&mut mutator, None);
 
+        assert_eq!(initialized_struct.ignored, 0);
+
+        initialized_struct.mutate(&mut mutator, None);
         assert_eq!(initialized_struct.ignored, 0);
     }
 


### PR DESCRIPTION
This solves the issue in #2 for me and modifies a test to prevent regression in the future.

Let me know what you think.